### PR TITLE
Modify class constructor to take in custom user name XML path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ const client = new SPCPAuthClient({
   appCert: '<the e-service public certificate issued to SingPass/CorpPass>',
   appKey: '<the e-service certificate private key>',
   spcpCert: '<the public certificate of SingPass/CorpPass, for OOB authentication>',
+  userNameXPath: '<custom XPath or SPCPAuthClient.xpaths.CORPPASS_UEN or SPCPAuthClient.xpaths.SINGPASS_NRIC (default)>',
 })
 
 const express = require('express')

--- a/SPCPAuthClient.class.js
+++ b/SPCPAuthClient.class.js
@@ -20,6 +20,7 @@ class SPCPAuthClient {
    * @param  {(String|Buffer)} config.appCert - the e-service public certificate issued to SingPass/CorpPass
    * @param  {(String|Buffer)} config.appKey - the e-service certificate private key
    * @param  {String} config.spcpCert - the public certificate of SingPass/CorpPass, for OOB authentication
+   * @param  {String} config.userNameXPath - Optional XPath for extracting userName from Artifact Response
    */
   constructor (config) {
     const PARAMS = [
@@ -39,8 +40,7 @@ class SPCPAuthClient {
         throw new Error(param + ' undefined')
       }
     }
-    this.userNameXmlPath = config.userNameXmlPath
-    || "string(//*[local-name(.)='Attribute'][@Name='UserName'])"
+    this.userNameXPath = config.userNameXPath || SPCPAuthClient.xpaths.SINGPASS_NRIC
     this.jwtAlgorithm = 'RS256'
   }
 
@@ -206,7 +206,7 @@ class SPCPAuthClient {
       if (err) {
         decryptionError = err
       } else {
-        userName = xpath.select(this.userNameXmlPath, 
+        userName = xpath.select(this.userNameXPath,
           new xmldom.DOMParser().parseFromString(decryptedData))
       }
       return { userName, decryptionError }
@@ -309,6 +309,12 @@ class SPCPAuthClient {
       }
     }
   }
+}
+
+// XPaths for extracting userName from Artifact Response
+SPCPAuthClient.xpaths = {
+  CORPPASS_UEN: "string(//*[local-name(.)='Attribute']/@Name)",
+  SINGPASS_NRIC: "string(//*[local-name(.)='Attribute'][@Name='UserName'])",
 }
 
 module.exports = SPCPAuthClient

--- a/SPCPAuthClient.class.js
+++ b/SPCPAuthClient.class.js
@@ -314,7 +314,7 @@ class SPCPAuthClient {
 // XPaths for extracting userName from Artifact Response
 SPCPAuthClient.xpaths = {
   CORPPASS_UEN: "string(//*[local-name(.)='Attribute']/@Name)",
-  SINGPASS_NRIC: "string(//*[local-name(.)='Attribute'][@Name='UserName'])",
+  SINGPASS_NRIC: "string(//*[local-name(.)='Attribute'][@Name='UserName']/*[local-name(.)='AttributeValue'])",
 }
 
 module.exports = SPCPAuthClient


### PR DESCRIPTION
* Extract user name from decrypted artifact response using custom user name XML path
* Default to user name XML path for SingPass to ensure backward compatibility
* This is needed as CorpPass/SingPass `userName` are located at different parts of `AttributeStatement`